### PR TITLE
【fixed】create rental property app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+public/uploads
+.env
+.DS_Store
+database_yml
+vendor/bundle
+/.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -3,52 +3,30 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.0.1'
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '6.0.3'
-# Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.4'
-# Use Puma as the app server
 gem 'puma', '~> 4.1'
-# Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
-# Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 4.0'
-# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
-# Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
-
-# Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 
 group :development do
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.2'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 group :test do
-  # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
-  # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'
 end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'webpacker', '~> 4.0'
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'faker'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     erubi (1.10.0)
+    faker (2.19.0)
+      i18n (>= 1.6, < 2)
     ffi (1.15.3)
     globalid (0.5.2)
       activesupport (>= 5.0)
@@ -206,6 +208,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  faker
   jbuilder (~> 2.7)
   listen (~> 3.2)
   puma (~> 4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.4-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.4-x86_64-darwin)
+      racc (~> 1.4)
     public_suffix (4.0.6)
     puma (4.3.8)
       nio4r (~> 2.0)
@@ -198,6 +200,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)
@@ -222,4 +225,4 @@ RUBY VERSION
    ruby 3.0.1p64
 
 BUNDLED WITH
-   2.2.21
+   2.3.10

--- a/app/assets/stylesheets/properties.scss
+++ b/app/assets/stylesheets/properties.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the properties controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,65 @@
+body {
+  background-color: #fff;
+  color: #333;
+  margin: 33px; }
+
+body, p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px; }
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px; }
+
+a {
+  color: #000; }
+
+a:visited {
+  color: #666; }
+
+a:hover {
+  color: #fff;
+  background-color: #000; }
+
+th {
+  padding-bottom: 5px; }
+
+td {
+  padding: 0 5px 7px; }
+
+div.field,
+div.actions {
+  margin-bottom: 10px; }
+
+#notice {
+  color: green; }
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table; }
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px 7px 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0; }
+
+#error_explanation h2 {
+  text-align: left;
+  font-weight: bold;
+  padding: 5px 5px 5px 15px;
+  font-size: 12px;
+  margin: -7px -7px 0;
+  background-color: #c00;
+  color: #fff; }
+
+#error_explanation ul li {
+  font-size: 12px;
+  list-style: square; }
+
+label {
+  display: block; }

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -1,0 +1,69 @@
+class PropertiesController < ApplicationController
+  before_action :set_property, only: %i[ show edit update destroy ]
+
+  # GET /properties or /properties.json
+  def index
+    @properties = Property.all
+  end
+
+  # GET /properties/1 or /properties/1.json
+  def show
+  end
+
+  # GET /properties/new
+  def new
+    @property = Property.new
+  end
+
+  # GET /properties/1/edit
+  def edit
+  end
+
+  # POST /properties or /properties.json
+  def create
+    @property = Property.new(property_params)
+
+    respond_to do |format|
+      if @property.save
+        format.html { redirect_to @property, notice: "Property was successfully created." }
+        format.json { render :show, status: :created, location: @property }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @property.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /properties/1 or /properties/1.json
+  def update
+    respond_to do |format|
+      if @property.update(property_params)
+        format.html { redirect_to @property, notice: "Property was successfully updated." }
+        format.json { render :show, status: :ok, location: @property }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @property.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /properties/1 or /properties/1.json
+  def destroy
+    @property.destroy
+    respond_to do |format|
+      format.html { redirect_to properties_url, notice: "Property was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_property
+      @property = Property.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def property_params
+      params.require(:property).permit(:property_name, :rent, :address, :property_age, :notes)
+    end
+end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -1,68 +1,47 @@
 class PropertiesController < ApplicationController
   before_action :set_property, only: %i[ show edit update destroy ]
 
-  # GET /properties or /properties.json
   def index
     @properties = Property.all
   end
 
-  # GET /properties/1 or /properties/1.json
   def show
   end
 
-  # GET /properties/new
   def new
     @property = Property.new
   end
 
-  # GET /properties/1/edit
   def edit
   end
 
-  # POST /properties or /properties.json
   def create
     @property = Property.new(property_params)
-
-    respond_to do |format|
-      if @property.save
-        format.html { redirect_to @property, notice: "Property was successfully created." }
-        format.json { render :show, status: :created, location: @property }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @property.errors, status: :unprocessable_entity }
-      end
+    if @property.save
+      redirect_to @property, notice: "Property was successfully created."
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
-  # PATCH/PUT /properties/1 or /properties/1.json
   def update
-    respond_to do |format|
-      if @property.update(property_params)
-        format.html { redirect_to @property, notice: "Property was successfully updated." }
-        format.json { render :show, status: :ok, location: @property }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @property.errors, status: :unprocessable_entity }
-      end
+    if @property.update(property_params)
+      redirect_to @property, notice: "Property was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 
-  # DELETE /properties/1 or /properties/1.json
   def destroy
     @property.destroy
-    respond_to do |format|
-      format.html { redirect_to properties_url, notice: "Property was successfully destroyed." }
-      format.json { head :no_content }
-    end
+    redirect_to properties_url, notice: "Property was successfully destroyed."
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
     def set_property
       @property = Property.find(params[:id])
     end
 
-    # Only allow a list of trusted parameters through.
     def property_params
       params.require(:property).permit(:property_name, :rent, :address, :property_age, :notes)
     end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -6,35 +6,38 @@ class PropertiesController < ApplicationController
   end
 
   def show
+    @closest_stations = @property.closest_stations
   end
 
   def new
     @property = Property.new
+    2.times { @property.closest_stations.build }
   end
 
   def edit
+    # @property.closest_stations.build
   end
 
   def create
     @property = Property.new(property_params)
     if @property.save
-      redirect_to @property, notice: "Property was successfully created."
+      redirect_to @property, notice: "物件を登録しました"
     else
-      render :new, status: :unprocessable_entity
+      render :new
     end
   end
 
   def update
     if @property.update(property_params)
-      redirect_to @property, notice: "Property was successfully updated."
+      redirect_to @property, notice: "物件を編集しました"
     else
-      render :edit, status: :unprocessable_entity
+      render :edit
     end
   end
 
   def destroy
     @property.destroy
-    redirect_to properties_url, notice: "Property was successfully destroyed."
+    redirect_to properties_url, notice: "物件を削除しました"
   end
 
   private
@@ -43,6 +46,11 @@ class PropertiesController < ApplicationController
     end
 
     def property_params
-      params.require(:property).permit(:property_name, :rent, :address, :property_age, :notes)
+      params.require(:property).permit(
+        :property_name, :rent, :address, :property_age, :notes,
+        closest_stations_attributes: %i[
+          track_name station_name walking_time
+        ],
+      )
     end
 end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -15,7 +15,7 @@ class PropertiesController < ApplicationController
   end
 
   def edit
-    # @property.closest_stations.build
+    @property.closest_stations.build
   end
 
   def create

--- a/app/helpers/properties_helper.rb
+++ b/app/helpers/properties_helper.rb
@@ -1,0 +1,2 @@
+module PropertiesHelper
+end

--- a/app/models/closest_station.rb
+++ b/app/models/closest_station.rb
@@ -1,0 +1,2 @@
+class ClosestStation < ApplicationRecord
+end

--- a/app/models/closest_station.rb
+++ b/app/models/closest_station.rb
@@ -1,2 +1,3 @@
 class ClosestStation < ApplicationRecord
+  belongs_to :property
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,0 +1,2 @@
+class Property < ApplicationRecord
+end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,4 +1,4 @@
 class Property < ApplicationRecord
   has_many :closest_stations, dependent: :destroy
-  accepts_nested_attributes_for :closest_stations, allow_destroy: :true
+  accepts_nested_attributes_for :closest_stations, allow_destroy: :true, reject_if: :all_blank
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,2 +1,4 @@
 class Property < ApplicationRecord
+  has_many :closest_stations, dependent: :destroy
+  accepts_nested_attributes_for :closest_stations, allow_destroy: :true
 end

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="field">
     <%= form.label :rent %>
-    <%= form.number_field :rent %>
+    <%= form.number_field :rent %>円
   </div>
 
   <div class="field">
@@ -28,7 +28,7 @@
 
   <div class="field">
     <%= form.label :property_age %>
-    <%= form.number_field :property_age %>
+    <%= form.number_field :property_age %>年
   </div>
 
   <div class="field">

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -36,6 +36,28 @@
     <%= form.text_area :notes %>
   </div>
 
+  <hr>
+  <% n=0 %>
+    <%= form.fields_for :closest_stations do |closest_station| %>
+      <h2>最寄り駅<%= "#{n+1}" %></h2>
+      <div class="field">
+        <%= closest_station.label :track_name %>
+        <%= closest_station.text_field :track_name %>
+      </div>
+
+      <div class="field">
+        <%= closest_station.label :station_name %>
+        <%= closest_station.text_field :station_name%>
+      </div>
+
+      <div class="field">
+        <%= closest_station.label :walking_time %>
+        <%= closest_station.text_area :walking_time %>分
+      </div>
+
+      <% n+=1 %>
+    <% end %>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -1,0 +1,42 @@
+<%= form_with(model: property, local: true) do |form| %>
+  <% if property.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(property.errors.count, "error") %> prohibited this property from being saved:</h2>
+
+      <ul>
+        <% property.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :property_name %>
+    <%= form.text_field :property_name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :rent %>
+    <%= form.number_field :rent %>
+  </div>
+
+  <div class="field">
+    <%= form.label :address %>
+    <%= form.text_area :address %>
+  </div>
+
+  <div class="field">
+    <%= form.label :property_age %>
+    <%= form.number_field :property_age %>
+  </div>
+
+  <div class="field">
+    <%= form.label :notes %>
+    <%= form.text_area :notes %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -18,12 +18,12 @@
 
   <div class="field">
     <%= form.label :rent %>
-    <%= form.number_field :rent %>円
+    <%= form.text_field :rent %>円
   </div>
 
   <div class="field">
     <%= form.label :address %>
-    <%= form.text_area :address %>
+    <%= form.text_field :address %>
   </div>
 
   <div class="field">
@@ -52,7 +52,7 @@
 
       <div class="field">
         <%= closest_station.label :walking_time %>
-        <%= closest_station.text_area :walking_time %>分
+        <%= closest_station.text_field:walking_time %>分
       </div>
 
       <% n+=1 %>

--- a/app/views/properties/_property.json.jbuilder
+++ b/app/views/properties/_property.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! property, :id, :property_name, :rent, :address, :property_age, :notes, :created_at, :updated_at
+json.url property_url(property, format: :json)

--- a/app/views/properties/_property.json.jbuilder
+++ b/app/views/properties/_property.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! property, :id, :property_name, :rent, :address, :property_age, :notes, :created_at, :updated_at
-json.url property_url(property, format: :json)

--- a/app/views/properties/edit.html.erb
+++ b/app/views/properties/edit.html.erb
@@ -1,6 +1,6 @@
-<h1>Editing Property</h1>
+<h1>物件編集</h1>
 
 <%= render 'form', property: @property %>
 
-<%= link_to 'Show', @property %> |
-<%= link_to 'Back', properties_path %>
+<%= link_to '詳細', @property %> |
+<%= link_to '戻る', properties_path %>

--- a/app/views/properties/edit.html.erb
+++ b/app/views/properties/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Property</h1>
+
+<%= render 'form', property: @property %>
+
+<%= link_to 'Show', @property %> |
+<%= link_to 'Back', properties_path %>

--- a/app/views/properties/index.html.erb
+++ b/app/views/properties/index.html.erb
@@ -1,15 +1,15 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Properties</h1>
+<h1>物件一覧</h1>
 
 <table>
   <thead>
     <tr>
-      <th>Property name</th>
-      <th>Rent</th>
-      <th>Address</th>
-      <th>Property age</th>
-      <th>Notes</th>
+      <th>物件名</th>
+      <th>賃料</th>
+      <th>住所</th>
+      <th>築年数</th>
+      <th>備考</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -22,9 +22,9 @@
         <td><%= property.address %></td>
         <td><%= property.property_age %></td>
         <td><%= property.notes %></td>
-        <td><%= link_to 'Show', property %></td>
-        <td><%= link_to 'Edit', edit_property_path(property) %></td>
-        <td><%= link_to 'Destroy', property, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to '詳細', property %></td>
+        <td><%= link_to '編集', edit_property_path(property) %></td>
+        <td><%= link_to '削除', property, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -32,4 +32,4 @@
 
 <br>
 
-<%= link_to 'New Property', new_property_path %>
+<%= link_to '物件を登録する', new_property_path %>

--- a/app/views/properties/index.html.erb
+++ b/app/views/properties/index.html.erb
@@ -1,0 +1,35 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Properties</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Property name</th>
+      <th>Rent</th>
+      <th>Address</th>
+      <th>Property age</th>
+      <th>Notes</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @properties.each do |property| %>
+      <tr>
+        <td><%= property.property_name %></td>
+        <td><%= property.rent %></td>
+        <td><%= property.address %></td>
+        <td><%= property.property_age %></td>
+        <td><%= property.notes %></td>
+        <td><%= link_to 'Show', property %></td>
+        <td><%= link_to 'Edit', edit_property_path(property) %></td>
+        <td><%= link_to 'Destroy', property, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Property', new_property_path %>

--- a/app/views/properties/index.json.jbuilder
+++ b/app/views/properties/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @properties, partial: "properties/property", as: :property

--- a/app/views/properties/index.json.jbuilder
+++ b/app/views/properties/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @properties, partial: "properties/property", as: :property

--- a/app/views/properties/new.html.erb
+++ b/app/views/properties/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Property</h1>
+
+<%= render 'form', property: @property %>
+
+<%= link_to 'Back', properties_path %>

--- a/app/views/properties/new.html.erb
+++ b/app/views/properties/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Property</h1>
+<h1>物件登録</h1>
 
 <%= render 'form', property: @property %>
 
-<%= link_to 'Back', properties_path %>
+<%= link_to '戻る', properties_path %>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -25,5 +25,17 @@
   <%= @property.notes %>
 </p>
 
+<hr>
+<% n=0 %>
+<% @closest_stations.each do |closest_station| %>
+  <% if @closest_stations.any? %>
+    <h2>最寄り駅<%= "#{n+1}" %></h2>
+    <%= closest_station.track_name %>
+    <%= closest_station.station_name %>
+    <%= closest_station.walking_time %>分
+    <% n+=1 %>
+  <% end %>
+<% end %>
+
 <%= link_to '編集', edit_property_path(@property) %> |
 <%= link_to '戻る', properties_path %>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -1,29 +1,29 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Property name:</strong>
+  <strong>物件名:</strong>
   <%= @property.property_name %>
 </p>
 
 <p>
-  <strong>Rent:</strong>
+  <strong>賃料:</strong>
   <%= @property.rent %>
 </p>
 
 <p>
-  <strong>Address:</strong>
+  <strong>住所:</strong>
   <%= @property.address %>
 </p>
 
 <p>
-  <strong>Property age:</strong>
+  <strong>築年数:</strong>
   <%= @property.property_age %>
 </p>
 
 <p>
-  <strong>Notes:</strong>
+  <strong>備考:</strong>
   <%= @property.notes %>
 </p>
 
-<%= link_to 'Edit', edit_property_path(@property) %> |
-<%= link_to 'Back', properties_path %>
+<%= link_to '編集', edit_property_path(@property) %> |
+<%= link_to '戻る', properties_path %>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Property name:</strong>
+  <%= @property.property_name %>
+</p>
+
+<p>
+  <strong>Rent:</strong>
+  <%= @property.rent %>
+</p>
+
+<p>
+  <strong>Address:</strong>
+  <%= @property.address %>
+</p>
+
+<p>
+  <strong>Property age:</strong>
+  <%= @property.property_age %>
+</p>
+
+<p>
+  <strong>Notes:</strong>
+  <%= @property.notes %>
+</p>
+
+<%= link_to 'Edit', edit_property_path(@property) %> |
+<%= link_to 'Back', properties_path %>

--- a/app/views/properties/show.json.jbuilder
+++ b/app/views/properties/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "properties/property", property: @property

--- a/app/views/properties/show.json.jbuilder
+++ b/app/views/properties/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "properties/property", property: @property

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,9 @@ Bundler.require(*Rails.groups)
 module DevExamRails6
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,2 +1,2 @@
-I18n.config.available_locales = :ja
+I18n.config.available_locales = [:ja, :en]
 I18n.default_locale = :ja

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,2 @@
+I18n.config.available_locales = :ja
+I18n.default_locale = :ja

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,221 @@
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+    models:
+      property: '物件'
+      closest_station: '最寄駅'
+    attributes:
+      property:
+        property_name: '物件名'
+        rent: '賃料'
+        address: '住所' 
+        property_age: '築年数'
+        notes: '備考'
+      closest_station:
+        track_name: '線路名'
+        station_name: '駅名'
+        walking_time: '徒歩分数'
+
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  resources :properties
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
+  root 'property#index'
   resources :properties
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -53,7 +53,7 @@ development:
   compile: true
 
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
+  check_yarn_integrity: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:

--- a/db/migrate/20220620235629_create_properties.rb
+++ b/db/migrate/20220620235629_create_properties.rb
@@ -1,0 +1,13 @@
+class CreateProperties < ActiveRecord::Migration[6.0]
+  def change
+    create_table :properties do |t|
+      t.string :property_name
+      t.integer :rent
+      t.text :address
+      t.integer :property_age
+      t.text :notes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220621000555_create_closest_stations.rb
+++ b/db/migrate/20220621000555_create_closest_stations.rb
@@ -1,0 +1,11 @@
+class CreateClosestStations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :closest_stations do |t|
+      t.string :track_name
+      t.string :station_name
+      t.integer :walking_time
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220621000904_add_property_ref_to_closest_stations.rb
+++ b/db/migrate/20220621000904_add_property_ref_to_closest_stations.rb
@@ -1,0 +1,5 @@
+class AddPropertyRefToClosestStations < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :closest_stations, :property, foreign_key: true
+  end
+end

--- a/db/migrate/20220621084019_change_column.rb
+++ b/db/migrate/20220621084019_change_column.rb
@@ -1,0 +1,15 @@
+class ChangeColumn < ActiveRecord::Migration[6.0]
+  def up
+    change_column :properties, :rent, :string
+    change_column :properties, :address, :string
+    change_column :properties, :property_age, :string
+    change_column :closest_stations, :walking_time, :string
+  end
+
+  def down
+    change_column :properties, :rent, :integer
+    change_column :properties, :address, :text
+    change_column :properties, :property_age, :integer
+    change_column :closest_stations, :walking_time, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,36 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2022_06_21_000904) do
+
+  create_table "closest_stations", force: :cascade do |t|
+    t.string "track_name"
+    t.string "station_name"
+    t.integer "walking_time"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "property_id"
+    t.index ["property_id"], name: "index_closest_stations_on_property_id"
+  end
+
+  create_table "properties", force: :cascade do |t|
+    t.string "property_name"
+    t.integer "rent"
+    t.text "address"
+    t.integer "property_age"
+    t.text "notes"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  add_foreign_key "closest_stations", "properties"
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_21_000904) do
+ActiveRecord::Schema.define(version: 2022_06_21_084019) do
 
   create_table "closest_stations", force: :cascade do |t|
     t.string "track_name"
     t.string "station_name"
-    t.integer "walking_time"
+    t.string "walking_time"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "property_id"
@@ -24,9 +24,9 @@ ActiveRecord::Schema.define(version: 2022_06_21_000904) do
 
   create_table "properties", force: :cascade do |t|
     t.string "property_name"
-    t.integer "rent"
-    t.text "address"
-    t.integer "property_age"
+    t.string "rent"
+    t.string "address"
+    t.string "property_age"
     t.text "notes"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,23 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+100.times do |n|
+  property_name = Faker::Creature::Cat.name
+  rent = Faker::Number.number(digits: 5)
+  address = Faker::Address.full_address
+  property_age = Faker::Number.number(digits: 2)
+  notes = Faker::Quote.famous_last_words
+  Property.create!(property_name: property_name,
+                  rent: rent,
+                  address: address,
+                  property_age: property_age,
+                  notes: notes,
+                  )
+  track_name = Faker::Superhero.name
+  station_name = Faker::Address.city
+  walking_time = Faker::Number.number(digits: 2)
+  ClosestStation.create!(track_name: track_name,
+                        station_name: station_name,
+                        walking_time: walking_time,
+                      )
+end

--- a/test/controllers/properties_controller_test.rb
+++ b/test/controllers/properties_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class PropertiesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @property = properties(:one)
+  end
+
+  test "should get index" do
+    get properties_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_property_url
+    assert_response :success
+  end
+
+  test "should create property" do
+    assert_difference('Property.count') do
+      post properties_url, params: { property: { address: @property.address, notes: @property.notes, property_age: @property.property_age, property_name: @property.property_name, rent: @property.rent } }
+    end
+
+    assert_redirected_to property_url(Property.last)
+  end
+
+  test "should show property" do
+    get property_url(@property)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_property_url(@property)
+    assert_response :success
+  end
+
+  test "should update property" do
+    patch property_url(@property), params: { property: { address: @property.address, notes: @property.notes, property_age: @property.property_age, property_name: @property.property_name, rent: @property.rent } }
+    assert_redirected_to property_url(@property)
+  end
+
+  test "should destroy property" do
+    assert_difference('Property.count', -1) do
+      delete property_url(@property)
+    end
+
+    assert_redirected_to properties_url
+  end
+end

--- a/test/fixtures/closest_stations.yml
+++ b/test/fixtures/closest_stations.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  track_name: MyString
+  station_name: MyString
+  walking_time: 1
+
+two:
+  track_name: MyString
+  station_name: MyString
+  walking_time: 1

--- a/test/fixtures/properties.yml
+++ b/test/fixtures/properties.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  property_name: MyString
+  rent: 1
+  address: MyText
+  property_age: 1
+  notes: MyText
+
+two:
+  property_name: MyString
+  rent: 1
+  address: MyText
+  property_age: 1
+  notes: MyText

--- a/test/models/closest_station_test.rb
+++ b/test/models/closest_station_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ClosestStationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/property_test.rb
+++ b/test/models/property_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PropertyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/properties_test.rb
+++ b/test/system/properties_test.rb
@@ -1,0 +1,51 @@
+require "application_system_test_case"
+
+class PropertiesTest < ApplicationSystemTestCase
+  setup do
+    @property = properties(:one)
+  end
+
+  test "visiting the index" do
+    visit properties_url
+    assert_selector "h1", text: "Properties"
+  end
+
+  test "creating a Property" do
+    visit properties_url
+    click_on "New Property"
+
+    fill_in "Address", with: @property.address
+    fill_in "Notes", with: @property.notes
+    fill_in "Property age", with: @property.property_age
+    fill_in "Property name", with: @property.property_name
+    fill_in "Rent", with: @property.rent
+    click_on "Create Property"
+
+    assert_text "Property was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Property" do
+    visit properties_url
+    click_on "Edit", match: :first
+
+    fill_in "Address", with: @property.address
+    fill_in "Notes", with: @property.notes
+    fill_in "Property age", with: @property.property_age
+    fill_in "Property name", with: @property.property_name
+    fill_in "Rent", with: @property.rent
+    click_on "Update Property"
+
+    assert_text "Property was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Property" do
+    visit properties_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Property was successfully destroyed"
+  end
+end


### PR DESCRIPTION
- accepts_nested_attributes_forメソッドを使用し、複数の子レコードを同時作成出来るように実装
- 最寄駅がゼロの場合、もしくは1つしかない物件も登録できるようにする
- 賃貸物件の新規登録画面・詳細画面において追加した最寄り駅の数を表示
- 編集画面では、あらたにひとつの最寄駅を登録できる入力欄を表示させること。(これにより、最寄駅の登録数が増えても対応できるようにする。)